### PR TITLE
Fix styling of Rails form submit buttons

### DIFF
--- a/app/assets/stylesheets/_forms.scss
+++ b/app/assets/stylesheets/_forms.scss
@@ -2,3 +2,7 @@ input:focus {
   border-bottom: 1px solid $grey-darken-3 !important;
   box-shadow: 0 1px 0 0 $grey-darken-3 !important;
 }
+
+#remember-me {
+  margin-bottom: 1em;
+}

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -15,6 +15,8 @@
   </div>
 
   <div class="actions">
-    <%= f.submit "Change my password", class: "btn waves-effect waves-light" %>
+    <%= content_tag :button, type: :submit, class: "btn waves-effect waves-light" do %>
+      Change my password
+    <% end %>
   </div>
 <% end %>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -9,6 +9,8 @@
   </div>
 
   <div class="actions">
-    <%= f.submit "Send me reset password instructions", class: "btn waves-effect waves-light" %>
+    <%= content_tag :button, type: :submit, class: "btn waves-effect waves-light" do %>
+      Send me reset password instructions
+    <% end %>
   </div>
 <% end %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -32,6 +32,8 @@
   </div>
 
   <div class="actions">
-    <%= f.submit "Register", class: "btn waves-effect waves-light" %>
+    <%= content_tag :button, type: :submit, class: "btn waves-effect waves-light" do %>
+      Register
+    <% end %>
   </div>
 <% end %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -12,13 +12,17 @@
   </div>
 
   <% if devise_mapping.rememberable? -%>
-    <div class="field">
+    <div id="remember-me" class="field">
       <%= f.check_box :remember_me %>
       <%= f.label :remember_me %>
     </div>
   <% end -%>
 
   <div class="actions">
-    <%= f.submit "Log in", class: "btn waves-effect waves-light" %>
+    <%= content_tag :button, type: :submit, class: "btn waves-effect waves-light" do %>
+      Log in
+    <% end %>
   </div>
+
+
 <% end %>

--- a/app/views/leagues/new.html.erb
+++ b/app/views/leagues/new.html.erb
@@ -21,7 +21,7 @@
     <%= form.label :rounds %>
     <%= form.number_field :rounds %>
   </div>
-  <div>
-    <%= form.submit "Create", class: "btn waves-effect waves-light" %>
-  </div>
+  <%= content_tag :button, type: :submit, class: "btn waves-effect waves-light" do %>
+    Create
+  <% end %>
 <% end %>

--- a/app/views/teams/new.html.erb
+++ b/app/views/teams/new.html.erb
@@ -13,7 +13,7 @@
     <%= form.label :short_name %>
     <%= form.text_field :short_name %>
   </div>
-  <div>
-    <%= form.submit "Create", class: "btn waves-effect waves-light" %>
-  </div>
+  <%= content_tag :button, type: :submit, class: "btn waves-effect waves-light" do %>
+    Create
+  <% end %>
 <% end %>


### PR DESCRIPTION
Rails `form_for` submit buttons are `<input>` tags. MaterializeCSS recommends using a button to submit a form, rather than an input tag (http://materializecss.com/buttons.html). Failure to do so results in the following style issue:

### Before
![image](https://cloud.githubusercontent.com/assets/3384090/9534470/9720b33e-4ce6-11e5-8a3d-9e30abdc8819.png)

### After
![image](https://cloud.githubusercontent.com/assets/3384090/9534485/b8c65868-4ce6-11e5-8912-ee3726ef4fa1.png)
