### PR TITLE
Scroll up to the draft ticker after a pick is made

### DIFF
--- a/app/assets/javascripts/components/draft_room.js.jsx.coffee
+++ b/app/assets/javascripts/components/draft_room.js.jsx.coffee
@@ -32,7 +32,10 @@
           playerId: selectedPlayerId
       method: 'POST'
       url: url
-      success: ((updatedData) => @refreshData(updatedData)).bind(@)
+      success: ((updatedData) =>
+        @refreshData(updatedData)
+        $(document).scrollTop( $("#draft-ticker").offset().top )
+      ).bind(@)
       error: ((xhr, status, err) -> console.error url, status, err.toString()).bind(@)
   selectPosition: (selectedPosition) ->
     @setState(players: @filterPlayersByPosition(selectedPosition))


### PR DESCRIPTION
Why:
After making a pick, the window remains scrolled to where the selected player had been. This makes it impossible to see which team was now on the clock.

How:
Scroll to the top of the draft ticker after a pick is made.