### PR TITLE
Seed sports and draft statuses in test

### DIFF
--- a/app/views/drafts/show.json.jbuilder
+++ b/app/views/drafts/show.json.jbuilder
@@ -1,4 +1,4 @@
-json.draftStatus(DraftStatus.find(@league.draft_status).description)
+json.draftStatus(DraftStatus.find(@league.draft_status_id).description)
 json.league(@league.id)
 json.picks(@picks) do |pick|
   json.id pick.id

--- a/spec/features/user_creates_league_spec.rb
+++ b/spec/features/user_creates_league_spec.rb
@@ -2,8 +2,6 @@ require 'spec_helper'
 
 feature 'Leagues - ' do
   before do
-    create(:draft_status)
-    create(:sport)
     sign_in create(:user)
   end
 

--- a/spec/models/player_spec.rb
+++ b/spec/models/player_spec.rb
@@ -11,9 +11,12 @@ describe Player do
 end
 
 describe Player do
+  before do
+    @football = Sport.find_by(name: 'Football')
+  end
+
   describe '.update_player_pool' do
     before do
-      @sport = create(:sport)
       player_data = "{
         \"body\":{
           \"players\":
@@ -46,7 +49,7 @@ describe Player do
     end
 
     it 'updates existing players' do
-      create(:player, sport: @sport)
+      create(:player, sport: @football)
 
       expect(Player.all.length).to eq 1
 
@@ -65,17 +68,16 @@ describe Player do
         'http://sports.cbsimg.net/images/blogs/Tom-brady.turkey.400.jpg'
       )
       expect(player.pro_status).to eq 'A'
-      expect(player.sport_id).to eq '1'
+      expect(player.sport_id).to eq @football.id.to_s
       expect(player.orig_id).to eq '1'
     end
   end
 
   describe '.undrafted' do
     it 'returns only undrafted players for a league' do
-      sport = create(:sport)
-      create(:player, last_name: 'undrafted', sport: sport)
-      drafted_player = create(:player, last_name: 'drafted', sport: sport)
-      league = create(:league, sport: sport)
+      create(:player, last_name: 'undrafted', sport: @football)
+      drafted_player = create(:player, last_name: 'drafted', sport: @football)
+      league = create(:league, sport: @football)
       team = create(:team, league: league)
 
       expect(Player.undrafted(League.last).length).to eq 2

--- a/spec/models/sport_spec.rb
+++ b/spec/models/sport_spec.rb
@@ -9,6 +9,10 @@ describe Sport do
 end
 
 describe Sport, '.seed' do
+  before do
+    Sport.destroy_all
+  end
+
   it 'inserts new sports' do
     sports = Sport.all
     expect(sports).to be_empty

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,4 +24,8 @@ RSpec.configure do |config|
   config.include Features::NavigationHelpers, type: :feature
   config.include Features::SessionHelpers, type: :feature
   config.include Features::TimingHelpers, type: :feature
+
+  config.before(:suite) do
+    Rails.application.load_seed
+  end
 end

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -1,17 +1,17 @@
 RSpec.configure do |config|
+  config.add_setting(:seed_tables)
+  config.seed_tables = %w(draft_statuses sports)
+
   config.before(:suite) do
     DatabaseCleaner.clean_with(:deletion)
   end
 
   config.before(:each) do
-    DatabaseCleaner.strategy = :transaction
-  end
-
-  config.before(:each, js: true) do
-    DatabaseCleaner.strategy = :truncation
-  end
-
-  config.before(:each) do
+    if example.metadata[:js]
+      DatabaseCleaner.strategy = :truncation, { except: config.seed_tables }
+    else
+      DatabaseCleaner.strategy = :transaction
+    end
     DatabaseCleaner.start
   end
 

--- a/spec/support/factories.rb
+++ b/spec/support/factories.rb
@@ -8,11 +8,7 @@ FactoryGirl.define do
   end
 
   factory :league do
-    after(:create) { DraftStatus.find_or_create_by(description: 'Complete') }
-    after(:create) { DraftStatus.find_or_create_by(description: 'In Progress') }
-    after(:create) { DraftStatus.find_or_create_by(description: 'Not Started') }
-
-    draft_status
+    draft_status { DraftStatus.find_or_create_by(description: 'Not Started') }
     name 'Fantasy Sports Dojo'
     password 'password'
     rounds 15
@@ -20,15 +16,15 @@ FactoryGirl.define do
     user
 
     factory :football_league do
-      sport
+      sport { Sport.find_or_create_by(name: 'Football') }
     end
 
     trait :with_draft_complete do
-      draft_status { create(:draft_status, description: 'Complete') }
+      draft_status { DraftStatus.find_or_create_by(description: 'Complete') }
     end
 
     trait :with_draft_in_progress do
-      draft_status { create(:draft_status, description: 'In Progress') }
+      draft_status { DraftStatus.find_or_create_by(description: 'In Progress') }
     end
   end
 

--- a/spec/support/features/data_preparation_helpers.rb
+++ b/spec/support/features/data_preparation_helpers.rb
@@ -1,13 +1,14 @@
 module Features
   module DataPreparationHelpers
     def create_player_pool
-      FactoryGirl.create(:player, sport: Sport.last)
-      2.times { FactoryGirl.create(:player, position: 'QB', sport: Sport.last) }
-      2.times { FactoryGirl.create(:player, position: 'RB', sport: Sport.last) }
-      2.times { FactoryGirl.create(:player, position: 'WR', sport: Sport.last) }
-      2.times { FactoryGirl.create(:player, position: 'TE', sport: Sport.last) }
-      2.times { FactoryGirl.create(:player, position: 'K', sport: Sport.last) }
-      2.times { FactoryGirl.create(:player, position: 'DST', sport: Sport.last) }
+      football = Sport.find_by(name: 'Football')
+      FactoryGirl.create(:player, sport: football)
+      2.times { FactoryGirl.create(:player, position: 'QB', sport: football) }
+      2.times { FactoryGirl.create(:player, position: 'RB', sport: football) }
+      2.times { FactoryGirl.create(:player, position: 'WR', sport: football) }
+      2.times { FactoryGirl.create(:player, position: 'TE', sport: football) }
+      2.times { FactoryGirl.create(:player, position: 'K', sport: football) }
+      2.times { FactoryGirl.create(:player, position: 'DST', sport: football) }
     end
 
     def fill_league(league)


### PR DESCRIPTION
**Why:**
There's some overhead associated with creating these values in tests, in order to ensure that associations are respected. Sometimes maneuvering is necessary to ensure that duplicates of such entries aren't created. Given that the supported sports and available draft statuses are fairly static, it hardly seemed worth the effort to add these values in each test and ensure their uniqueness. 

**How:**
Run seeds before the test suite runs and ensure that these tables aren't cleaned by database cleaner.