### PR TITLE
Reduce application memory footprint

### DIFF
--- a/app/assets/javascripts/components/draft_room.js.jsx.coffee
+++ b/app/assets/javascripts/components/draft_room.js.jsx.coffee
@@ -1,22 +1,27 @@
 @pickDuration = 120
 @DraftRoom = React.createClass
-  getFirstUnusedPick: (picks) -> _(picks).filter(player: null)[0]
   getInitialState: ->
-    picks = @props.picks
     selectedPosition = getFirstOption(@props.positions)
 
-    currentPick: @getFirstUnusedPick(picks)
+    currentPick: @props.currentPick
     draftStatus: @props.draftStatus
-    picks: picks
+    picks: @props.picks
     players: @filterPlayersByPosition(selectedPosition)
     selectedPosition: selectedPosition
+    userIsLeagueManager: @props.currentUser is @props.leagueManager
   filterPlayersByPosition: (selectedPosition, players = @props.players) ->
     if selectedPosition is 'ALL' then players else _(players).filter(position: selectedPosition)
   refreshData: (updatedData) ->
-    @setState({ currentPick: @getFirstUnusedPick(updatedData.picks) })
+    updatedPlayers =
+      if updatedData.isUndo
+        @state.players.push updatedData.lastSelectedPlayer
+        _(@state.players).sortBy (player) -> player.lastName
+      else if updatedData.lastSelectedPlayer?
+        _(@state.players).reject (player) -> player.id is updatedData.lastSelectedPlayer.id
     @setState({ draftStatus: updatedData.draftStatus })
-    @setState({ picks: updatedData.picks })
-    @setState({ players: @filterPlayersByPosition(@state.selectedPosition, updatedData.players) })
+    @setState({ picks: @updatePicks(updatedData.lastSelectedPlayer, updatedData.isUndo) })
+    @setState({ players: @filterPlayersByPosition(@state.selectedPosition, updatedPlayers) })
+    @setState({ currentPick: updatedData.currentPick })
   selectPlayer: (selectedPlayerId, e) ->
     e.preventDefault()
     player = _(@state.players).findWhere({id: selectedPlayerId})
@@ -34,7 +39,9 @@
       url: url
       success: ((updatedData) =>
         @refreshData(updatedData)
-        $(document).scrollTop( $("#draft-ticker").offset().top )
+        draftTicker = $("#draft-ticker")
+        if draftTicker.length
+          $(document).scrollTop(draftTicker.offset().top)
       ).bind(@)
       error: ((xhr, status, err) -> console.error url, status, err.toString()).bind(@)
   selectPosition: (selectedPosition) ->
@@ -48,6 +55,18 @@
       url: url
       success: ((updatedData) => @refreshData(updatedData)).bind(@)
       error: ((xhr, status, err) -> console.error url, status, err.toString()).bind(@)
+  updatePicks: (lastSelectedPlayer, isUndo) ->
+    return unless lastSelectedPlayer?
+    currentPick = @state.currentPick.id
+    picks = @state.picks
+    picks.forEach (pick) ->
+      if pick.id is currentPick
+        pick.player =
+          if isUndo
+            undefined
+          else
+            "#{lastSelectedPlayer.lastName}, #{lastSelectedPlayer.firstName}"
+    picks
   render: ->
     if @state.draftStatus is 'Complete' or @state.currentPick is undefined
       `<div className="row">
@@ -61,7 +80,7 @@
         <DraftTicker
           currentPick={this.state.currentPick}
           picks={this.state.picks}
-          showAdminButtons={this.props.userIsLeagueManager}
+          showAdminButtons={this.state.userIsLeagueManager}
           teams={this.props.teams}
           undoLastPick={this.undoLastPick}
         />
@@ -79,7 +98,7 @@
        </div>`
 
 @DraftTicker = React.createClass
-  componentWillReceiveProps: (newProps) -> @setState({ currentPickId: newProps.currentPick.id })
+  componentWillReceiveProps: (newProps) -> @setState({ currentPickId: newProps.currentPick?.id })
   getInitialState: ->
     currentPickId: @props.currentPick?.id
     timerPaused: false
@@ -114,7 +133,6 @@
           >
             {pausePlayIcon}
           </button>
-
           <button
             className="btn btn-icon waves-effect waves-light"
             id="undo-last-pick"

--- a/app/assets/javascripts/components/shared.js.jsx.coffee
+++ b/app/assets/javascripts/components/shared.js.jsx.coffee
@@ -1,9 +1,9 @@
 @getFirstOption = (options) -> if _(options).any() then options[0].value else null
 @getPlayerName = (player) ->
-  if !!player.first_name
-    "#{player.last_name}, #{player.first_name}"
+  if !!player.firstName
+    "#{player.lastName}, #{player.firstName}"
   else
-    player.last_name
+    player.lastName
 @getSecondOption = (options) -> if _(options).any() then options[1].value else null
 @getSelection = (options) ->
   selection = []

--- a/app/controllers/draft_picks_controller.rb
+++ b/app/controllers/draft_picks_controller.rb
@@ -1,9 +1,13 @@
 class DraftPicksController < ApplicationController
   def create
-    pick = Pick.find(create_params['pick_id'])
-    pick.player_id = create_params['player_id']
+    pick = Pick.find(create_params[:pick_id])
+    league = pick.league
+    pick.player_id = create_params[:player_id]
     if pick.save
-      redirect_back(fallback_location: league_draft_path)
+      if league.picks.where(player_id: nil).count == 0
+        league.complete_draft
+      end
+      render json: league.draft_state.try(:camelize)
     else
       flash.alert = 'Unable to save pick'
     end
@@ -20,10 +24,27 @@ class DraftPicksController < ApplicationController
       Pick.execute_trade(trade_params)
       redirect_to action: :edit, status: 303
     else
-      last_pick = League.find(undo_params).picks.where.not(player_id: nil, keeper: true).last
+      league = League.find(undo_params)
+      last_pick = league.picks.where.not(keeper: true, player_id: nil).last
+      last_pick_player = last_pick.player
       last_pick.player_id = nil
       if last_pick.save
-        redirect_to league_draft_path(undo_params), status: 303
+        if last_pick.last_pick_of_draft?
+          league.begin_draft
+        end
+        draft_state = league.draft_state.merge(
+          is_undo: true,
+          last_selected_player: {
+            id: last_pick_player.id,
+            first_name: last_pick_player.first_name,
+            last_name: last_pick_player.last_name,
+            position: last_pick_player.position,
+            team: last_pick_player.team,
+            injury: last_pick_player.injury,
+            headline: last_pick_player.headline
+          }
+        ).camelize
+        render json: draft_state
       else
         flash.alert = 'Unable to undo pick'
       end

--- a/app/controllers/drafts_controller.rb
+++ b/app/controllers/drafts_controller.rb
@@ -1,18 +1,28 @@
 class DraftsController < ApplicationController
+  before_action :ensure_draft_has_started
+
   def show
-    @league = League.find(draft_params)
-    @teams = @league.teams.sort_by(&:draft_pick)
-    @picks = @league.picks.joins('LEFT JOIN players ON picks.player_id = players.id').select(
+    @league = league
+    @teams = league.teams.sort_by(&:draft_pick)
+    @picks = league.picks.joins('LEFT JOIN players ON picks.player_id = players.id').select(
       'picks.*, players.first_name as player_first_name, players.last_name as player_last_name'
     ).order(:id)
-    @players = Player.undrafted(@league).sort_by { |p| [p.last_name, p.first_name] }
-    @positions = Sport.get_positions(Sport.find(@league.sport.id))
-    @league.update_draft_status
+    @players = Player.undrafted(league).sort_by { |p| [p.last_name, p.first_name] }
+    @positions = Sport.get_positions(Sport.find(league.sport.id))
   end
 
   private
 
-  def draft_params
+  def ensure_draft_has_started
+    return unless league.draft_not_started?
+    league.begin_draft
+  end
+
+  def league
+    @league ||= League.find(league_id)
+  end
+
+  def league_id
     params.require(:league_id)
   end
 end

--- a/app/models/league.rb
+++ b/app/models/league.rb
@@ -11,17 +11,39 @@ class League < ActiveRecord::Base
   has_many :picks, through: :teams
   has_many :teams, dependent: :delete_all
 
-  def update_draft_status
-    completed_draft_status_id = DraftStatus.find_by(description: 'Complete').id
-    in_progress_draft_status_id = DraftStatus.find_by(description: 'In Progress').id
-    not_started_draft_status_id = DraftStatus.find_by(description: 'Not Started').id
-    picks_remaining = picks.where(player_id: nil).length
+  def begin_draft
+    update_attributes(draft_status: DraftStatus.find_by(description: 'In Progress'))
+  end
 
-    if draft_status_id == not_started_draft_status_id ||
-      (picks_remaining > 0 && draft_status_id == completed_draft_status_id)
-      update_attributes(draft_status_id: in_progress_draft_status_id)
-    elsif picks_remaining == 0 && draft_status_id == in_progress_draft_status_id
-      update_attributes(draft_status_id: completed_draft_status_id)
-    end
+  def complete_draft
+    update_attributes(draft_status: DraftStatus.find_by(description: 'Complete'))
+  end
+
+  def current_pick
+    picks.order(:id)
+      .select(:id, :overall_pick, :round, :round_pick, :team_id)
+      .find_by(player_id: nil)
+  end
+
+  def draft_not_started?
+    draft_status == DraftStatus.find_by(description: 'Not Started')
+  end
+
+  def draft_state
+    last_pick = current_pick.try(:previous)
+    {
+      current_pick: current_pick.try(:attributes),
+      last_selected_player: last_pick ? player_info(last_pick.player_id) : nil,
+      league_id: id,
+      draft_status: draft_status.description
+    }
+  end
+
+  private
+
+  def player_info(player_id)
+    Player.select(:id, :first_name, :last_name, :position, :team, :injury, :headline)
+      .find(player_id)
+      .attributes
   end
 end

--- a/app/models/pick.rb
+++ b/app/models/pick.rb
@@ -7,6 +7,14 @@ class Pick < ActiveRecord::Base
   belongs_to :team
   has_one :league, through: :team
 
+  def last_pick_of_draft?
+    self.class.find_by('id > ?', id).nil?
+  end
+
+  def previous
+    self.class.where('id < ?', id).last
+  end
+
   def self.create_picks(league)
     remove_picks(league)
     draft_order = league.teams.sort_by(&:draft_pick)

--- a/app/views/drafts/show.json.jbuilder
+++ b/app/views/drafts/show.json.jbuilder
@@ -1,5 +1,9 @@
+json.key_format! camelize: :lower
+json.currentPick(@league.current_pick.try(:attributes).try(:camelize))
+json.currentUser(current_user.id)
 json.draftStatus(DraftStatus.find(@league.draft_status_id).description)
 json.league(@league.id)
+json.leagueManager(@league.user_id)
 json.picks(@picks) do |pick|
   json.id pick.id
   json.overallPick pick.overall_pick
@@ -21,5 +25,3 @@ end
 json.teams(@teams) do |team|
   json.extract! team, :id, :name
 end
-
-json.userIsLeagueManager(current_user.id == @league.user_id)

--- a/config/initializers/core_extensions.rb
+++ b/config/initializers/core_extensions.rb
@@ -1,0 +1,1 @@
+Dir[File.join(Rails.root, "lib", "core_ext", "*.rb")].each { |file| require file }

--- a/lib/core_ext/hash.rb
+++ b/lib/core_ext/hash.rb
@@ -1,0 +1,5 @@
+Hash.class_eval do
+  def camelize
+    Hash[map { |k, v| [k.to_s.camelcase(:lower), v.respond_to?(:keys) ? v.camelize : v] }]
+  end
+end

--- a/spec/controllers/draft_picks_controller_spec.rb
+++ b/spec/controllers/draft_picks_controller_spec.rb
@@ -1,0 +1,141 @@
+require 'rails_helper'
+
+describe DraftPicksController do
+  context '#create' do
+    before do
+      sign_in create(:user)
+    end
+
+    before do
+      @league = create(:football_league, :with_draft_in_progress)
+      @team = create(:team, league: @league)
+      @pick = create(:pick, team: @team)
+      @player = create(:player, sport: @league.sport)
+
+      expect(@league.draft_status.description).to eq 'In Progress'
+    end
+
+    it 'assigns a player to the draft pick' do
+      post :create, params: {
+        league_id: @league.id,
+        pick: {
+          pick_id: @pick.id,
+          player_id: @player.id
+        }
+      }
+      expect(Pick.find(@pick.id).player).to eq @player
+    end
+
+    it 'renders the draft state' do
+      create(:pick, team: @team)
+      post :create, params: {
+        league_id: @league.id,
+        pick: {
+          pick_id: @pick.id,
+          player_id: @player.id
+        }
+      }
+      expect(@response.body).to eq @league.draft_state.camelize.to_json
+    end
+
+    it 'completes the draft if no picks remain' do
+      post :create, params: {
+        league_id: @league.id,
+        pick: {
+          pick_id: @pick.id,
+          player_id: @player.id
+        }
+      }
+      expect(League.find(@league.id).draft_status.description).to eq 'Complete'
+    end
+
+    it 'does not complete the draft if additional picks remain' do
+      create(:pick, team: @team)
+      post :create, params: {
+        league_id: @league.id,
+        pick: {
+          pick_id: @pick.id,
+          player_id: @player.id
+        }
+      }
+      expect(League.find(@league.id).draft_status.description).to eq 'In Progress'
+    end
+  end
+
+  context '#update' do
+    before do
+      sign_in create(:user)
+    end
+
+    it 'clears the player from the last draft pick' do
+      league = create(:football_league, :with_draft_in_progress)
+      team = create(:team, league: league)
+      player = create(:player, sport: league.sport)
+      pick = create(:pick, player: player, team: team)
+
+      post :update, params: { league_id: league.id }
+      expect(Pick.find(pick.id).player).to be_nil
+    end
+
+    it 'renders the draft state (with some additional data)' do
+      league = create(:football_league, :with_draft_in_progress)
+      team = create(:team, league: league)
+      player = create(:player, sport: league.sport)
+      create(:pick, player: player, team: team)
+
+      post :update, params: { league_id: league.id }
+
+      draft_state = league.draft_state.merge(
+        is_undo: true,
+        last_selected_player: {
+          id: player.id,
+          first_name: player.first_name,
+          last_name: player.last_name,
+          position: player.position,
+          team: player.team,
+          injury: player.injury,
+          headline: player.headline
+        }
+      )
+      expect(@response.body).to eq draft_state.camelize.to_json
+    end
+
+    it 'does not undo keepers' do
+      league = create(:football_league, :with_draft_in_progress)
+      team = create(:team, league: league)
+      player_one = create(:player, sport: league.sport)
+      player_two = create(:player, sport: league.sport)
+      pick = create(:pick, player: player_one, team: team)
+      keeper = create(:pick, player: player_two, team: team, keeper: true)
+
+      post :update, params: { league_id: league.id }
+      expect(Pick.find(keeper.id).player).to eq player_two
+      expect(Pick.find(pick.id).player).to be_nil
+    end
+
+    it "sets draft status to 'in progress' if the last pick is undone" do
+      league = create(:football_league, :with_draft_complete)
+      team = create(:team, league: league)
+      player = create(:player, sport: league.sport)
+      create(:pick, player: player, team: team)
+
+      expect(league.draft_status.description).to eq 'Complete'
+
+      post :update, params: { league_id: league.id }
+      expect(League.find(league.id).draft_status.description).to eq 'In Progress'
+    end
+
+    it 'does not change draft status if any pick other than the last is undone' do
+      league = create(:football_league, :with_draft_in_progress)
+      team = create(:team, league: league)
+      player = create(:player, sport: league.sport)
+      create(:pick, player: player, team: team)
+      create(:pick, team: @team)
+
+      expect(league.draft_status.description).to eq 'In Progress'
+
+      post :update, params: { league_id: league.id }
+      expect(League.find(league.id).draft_status.description).to eq 'In Progress'
+    end
+  end
+end

--- a/spec/controllers/drafts_controller_spec.rb
+++ b/spec/controllers/drafts_controller_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+describe DraftsController do
+  context '#show' do
+    before do
+      sign_in create(:user)
+    end
+
+    it 'begins the draft if not yet started' do
+      @league = create(:football_league, :with_draft_not_started)
+
+      expect(@league.draft_status.description).to eq 'Not Started'
+    end
+
+    it 'does nothing if the draft has already started' do
+      @league = create(:football_league, :with_draft_in_progress)
+
+      expect(@league.draft_status.description).to eq 'In Progress'
+    end
+
+    after do
+      get :show, params: { league_id: @league.id }
+      expect(League.find(@league.id).draft_status.description).to eq 'In Progress'
+    end
+  end
+end

--- a/spec/features/draft_spec.rb
+++ b/spec/features/draft_spec.rb
@@ -33,13 +33,17 @@ feature 'League draft room', js: true do
   end
 
   scenario 'completes the draft when no picks remain' do
-    sign_in @league_member
-    navigate_to_league
-    use_league_draft_picks(@league)
+    league = create(:football_league, :with_draft_in_progress, name: 'Completed draft')
+    league_member = create(:user)
+    team = create(:team, league: league, user: league_member)
+    create(:pick, team: team)
+
+    sign_in league_member
+    navigate_to_league(league.name)
     league_on_page.enter_draft
+    draft_room.select_player(draft_room.first_player_name)
 
     expect(draft_room).to have_link_to_draft_results
-    expect(League.last.draft_status_id).to eq DraftStatus.find_by(description: 'Complete').id
   end
 
   describe 'draft ticker' do

--- a/spec/models/league_spec.rb
+++ b/spec/models/league_spec.rb
@@ -13,31 +13,95 @@ describe League do
   it { should have_many(:picks) }
   it { should have_many(:teams) }
 
-  describe '.update_draft_status' do
-    it 'starts the draft if it has not been started yet' do
-      league = create(:football_league)
-      expect(league.draft_status_id).to eq DraftStatus.find_by(description: 'Not Started').id
+  describe '#begin_draft' do
+    it "sets draft status 'in progress' if it hasn't started yet" do
+      league = create(:football_league, :with_draft_not_started)
+      expect(league.draft_status.description).to eq 'Not Started'
 
-      league.update_draft_status
-      expect(League.last.draft_status_id).to eq DraftStatus.find_by(description: 'In Progress').id
+      league.begin_draft
+      expect(league.draft_status.description).to eq 'In Progress'
     end
+  end
 
-    it 'completes the draft after all picks have been made' do
+  describe '#complete_draft' do
+    it "sets draft status 'in progress' if it hasn't completed yet" do
       league = create(:football_league, :with_draft_in_progress)
-      expect(league.draft_status_id).to eq DraftStatus.find_by(description: 'In Progress').id
+      expect(league.draft_status.description).to eq 'In Progress'
 
-      league.update_draft_status
-      expect(League.last.draft_status_id).to eq DraftStatus.find_by(description: 'Complete').id
+      league.complete_draft
+      expect(league.draft_status.description).to eq 'Complete'
+    end
+  end
+
+  describe '#current_pick' do
+    it "returns the current pick for the selected league's draft" do
+      league = create(:football_league)
+      team_with_first_pick = create(:team, league: league)
+      first_pick = create(:pick, team: team_with_first_pick)
+      team_with_second_pick = create(:team, league: league)
+      keeper = create(:player, sport: league.sport)
+      create(:pick, keeper: true, player: keeper, team: team_with_second_pick)
+      team_with_third_pick = create(:team, league: league)
+      third_pick = create(:pick, team: team_with_third_pick)
+
+      expect(league.current_pick).to eq first_pick
+
+      first_pick.player = create(:player, sport: league.sport)
+      first_pick.save!
+
+      expect(league.current_pick).to eq third_pick
+    end
+  end
+
+  describe '#draft_not_started?' do
+    it 'returns true if the draft has not started' do
+      league = create(:football_league, :with_draft_not_started)
+      expect(league.draft_not_started?).to be_truthy
     end
 
-    it 'will undo completion if there are picks to be made' do
-      league = create(:football_league, :with_draft_complete)
-      team = create(:team, league: league)
-      create(:pick, player: nil, team: team)
-      expect(league.draft_status_id).to eq DraftStatus.find_by(description: 'Complete').id
+    it 'returns false if the draft is in progress' do
+      league = create(:football_league, :with_draft_in_progress)
+      expect(league.draft_not_started?).to be_falsy
+    end
 
-      league.update_draft_status
-      expect(League.last.draft_status_id).to eq DraftStatus.find_by(description: 'In Progress').id
+    it 'returns false if the draft is complete' do
+      league = create(:football_league, :with_draft_complete)
+      expect(league.draft_not_started?).to be_falsy
+    end
+  end
+
+  describe '#draft_state' do
+    it 'returns pertinent draft information' do
+      league = create(:football_league)
+      team_with_first_pick = create(:team, league: league)
+      team_with_second_pick = create(:team, league: league)
+      first_pick = create(:pick, team: team_with_first_pick)
+      create(:pick, team: team_with_second_pick)
+
+      expect(league.draft_state[:current_pick]).to eq(
+        'id' => first_pick.id,
+        'overall_pick' => first_pick.overall_pick,
+        'round' => first_pick.round,
+        'round_pick' => first_pick.round_pick,
+        'team_id' => first_pick.team_id
+      )
+      expect(league.draft_state[:last_selected_player]).to be_nil
+      expect(league.draft_state[:league_id]).to eq league.id
+      expect(league.draft_state[:draft_status]).to eq 'Not Started'
+
+      selected_player = create(:player, sport: league.sport)
+      first_pick.player = selected_player
+      first_pick.save!
+
+      expect(league.draft_state[:last_selected_player]).to eq(
+        'id' => selected_player.id,
+        'first_name' => selected_player.first_name,
+        'last_name' => selected_player.last_name,
+        'position' => selected_player.position,
+        'team' => selected_player.team,
+        'injury' => selected_player.injury,
+        'headline' => selected_player.headline
+      )
     end
   end
 end

--- a/spec/models/pick_spec.rb
+++ b/spec/models/pick_spec.rb
@@ -9,6 +9,40 @@ describe Pick do
   it { should belong_to(:team) }
   it { should have_one(:league) }
 
+  describe '#last_pick_of_draft?' do
+    before do
+      league = create(:football_league, :with_draft_in_progress)
+      team = create(:team, league: league)
+      @pick = create(:pick, team: team)
+    end
+
+    it 'returns true if it is last pick in draft' do
+      expect(@pick.last_pick_of_draft?).to be_truthy
+    end
+
+    it 'returns false if there are picks remaining' do
+      create(:pick, team: @team)
+      expect(@pick.last_pick_of_draft?).to be_falsy
+    end
+  end
+
+  describe '#previous' do
+    before do
+      league = create(:football_league, :with_draft_in_progress)
+      @team = create(:team, league: league)
+      @pick = create(:pick, team: @team)
+    end
+
+    it 'returns the previous pick, if it exists' do
+      pick = create(:pick, team: @team)
+      expect(pick.previous).to eq @pick
+    end
+
+    it 'returns nil if there is no previous pick' do
+      expect(@pick.previous).to be_nil
+    end
+  end
+
   describe '.create_picks' do
     before do
       @league = create(:football_league, rounds: 16)

--- a/spec/support/factories.rb
+++ b/spec/support/factories.rb
@@ -26,6 +26,10 @@ FactoryGirl.define do
     trait :with_draft_in_progress do
       draft_status { DraftStatus.find_or_create_by(description: 'In Progress') }
     end
+
+    trait :with_draft_not_started do
+      draft_status { DraftStatus.find_or_create_by(description: 'Not Started') }
+    end
   end
 
   factory :pick do

--- a/spec/support/features/data_preparation_helpers.rb
+++ b/spec/support/features/data_preparation_helpers.rb
@@ -22,12 +22,5 @@ module Features
     def generate_draft_picks(league)
       Pick.create_picks(League.find(league.id))
     end
-
-    def use_league_draft_picks(league)
-      league.picks.each do |pick|
-        pick.player_id = Player.first.id
-        pick.save
-      end
-    end
   end
 end


### PR DESCRIPTION
Why:
Each time a pick was made or undone, a call was made to the drafts_controller to fetch the new draft state (picks, players, etc.). This turned out to be a significant amount of data, particularly for baseball, which has roughly five times as many players as football.

This design will not allow for a reactive application running on basic hardware, as the memory consumed by doing such a load for 12 parallel users is too high.

How:
Manage the draft state on the client. After the initial draft room load, responses from the server should only pass the incremental data required to maintain said state.