### PR TITLE
Remove players from player pool

### DIFF
--- a/app/controllers/keepers_controller.rb
+++ b/app/controllers/keepers_controller.rb
@@ -26,12 +26,10 @@ class KeepersController < ApplicationController
 
   def edit
     @league = League.find(league_id)
-    sport = Sport.find(@league.sport.id)
     @available_picks = @league.picks.where(player_id: nil).sort_by(&:overall_pick)
     @keepers = @league.picks.where(keeper: true).sort_by(&:overall_pick).map(&:player)
-    kept_player_ids = @keepers.map(&:id)
-    @available_players = sport.players.where.not(id: kept_player_ids)
-    @positions = sport.position_options
+    @available_players = Player.undrafted(@league)
+    @positions = @league.sport.position_options
     @teams = @league.teams.sort_by(&:draft_pick)
   end
 

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -29,8 +29,9 @@ class Player < ActiveRecord::Base
 
         filtered_player_ids = filtered_players.map { |player| player['id'] }
         today = Time.zone.now
-        sport.players.each do |player|
+        sport.players.where(deleted_at: nil).each do |player|
           unless filtered_player_ids.include? player.orig_id
+            logger.info "Removed #{player.last_name}, #{player.first_name}"
             player.deleted_at = today
             player.save!
           end
@@ -65,6 +66,7 @@ class Player < ActiveRecord::Base
   private_class_method :outfield_positions
 
   def self.set_player_attributes(player_record, player)
+    player_record.deleted_at = nil
     player_record.first_name = player['firstname']
     player_record.headline = player.try(:[], 'icons').try(:[], 'headline')
     player_record.injury = player.try(:[], 'icons').try(:[], 'injury')

--- a/app/views/leagues/show.html.erb
+++ b/app/views/leagues/show.html.erb
@@ -9,39 +9,40 @@
     <i class="material-icons right">assignment</i><%= if @draft_status == 'Not Started' then 'View Draft Order' else 'Draft Results' end %>
   <% end %>
 
-  <%
-    unless @user.teams.any? { |team| team.league_id == @league.id } ||
-      @league.teams.length >= @league.size
-  %>
+  <% unless @user.teams.any? { |team| team.league_id == @league.id } || @league.teams.length >= @league.size %>
     <%= link_to new_league_team_path(@league.id), class: "btn waves-effect waves-light" do %>
       <i class="material-icons right">plus_one</i>New Team
     <% end %>
   <% end %>
 
-  <% if @user.id == @owner_id %>
-    <% if @draft_status == 'Not Started' and @league_full %>
-      <%= link_to league_draft_order_path(@league.id), class: "btn waves-effect waves-light" do %>
-        <i class="material-icons right">format_list_numbered</i>Set Draft Order
+  <% if @league_full %>
+    <% if @user.id == @owner_id %>
+      <% if @draft_status == 'Not Started' %>
+        <%= link_to league_draft_order_path(@league.id), class: "btn waves-effect waves-light" do %>
+          <i class="material-icons right">format_list_numbered</i>Set Draft Order
+        <% end %>
       <% end %>
-    <% end %>
-    <% if @has_generated_picks %>
-      <%= link_to edit_league_keepers_path(@league.id), class: "btn waves-effect waves-light" do %>
-        <i class="material-icons right">person_add</i>Set Keepers
-      <% end %>
-      <%= link_to edit_league_draft_picks_path(@league.id), class: "btn waves-effect waves-light" do %>
-        <i class="material-icons right">swap_horiz</i>Trade Picks
-      <% end %>
-      <% if @draft_status == 'Not Started' and @league_full %>
-        <%= link_to league_draft_path(@league.id), class: "btn waves-effect waves-light" do %>
-          <i class="material-icons right">play_circle_outline</i>Start Draft
+      <% if @has_generated_picks %>
+        <% if @draft_status != 'Complete' %>
+          <%= link_to edit_league_draft_picks_path(@league.id), class: "btn waves-effect waves-light" do %>
+            <i class="material-icons right">swap_horiz</i>Trade Picks
+          <% end %>
+        <% end %>
+        <% if @draft_status == 'Not Started' %>
+          <%= link_to edit_league_keepers_path(@league.id), class: "btn waves-effect waves-light" do %>
+            <i class="material-icons right">person_add</i>Set Keepers
+          <% end %>
+          <%= link_to league_draft_path(@league.id), class: "btn waves-effect waves-light" do %>
+            <i class="material-icons right">play_circle_outline</i>Start Draft
+          <% end %>
         <% end %>
       <% end %>
     <% end %>
-  <% end %>
 
-  <% if @draft_status == 'In Progress' %>
-    <%= link_to league_draft_path(@league.id), class: "btn waves-effect waves-light" do %>
-      <i class="material-icons right">open_in_browser</i>Join Draft
+    <% if @draft_status == 'In Progress' %>
+      <%= link_to league_draft_path(@league.id), class: "btn waves-effect waves-light" do %>
+        <i class="material-icons right">open_in_browser</i>Join Draft
+      <% end %>
     <% end %>
   <% end %>
 </div>

--- a/db/migrate/20160427142933_add_deleted_at_to_players.rb
+++ b/db/migrate/20160427142933_add_deleted_at_to_players.rb
@@ -1,0 +1,6 @@
+class AddDeletedAtToPlayers < ActiveRecord::Migration[5.0]
+  def change
+    add_column :players, :deleted_at, :datetime
+    add_index :players, :deleted_at
+  end
+end

--- a/spec/features/draft_spec.rb
+++ b/spec/features/draft_spec.rb
@@ -46,8 +46,9 @@ feature 'League draft room', js: true do
     navigate_to_league
     league_on_page.enter_draft
 
-    draft_room.select_player(draft_room.first_player_name)
-    expect(draft_room).to have_selected_player(draft_room.first_player_name)
+    player_name = draft_room.get_player_name(Player.first)
+    draft_room.select_player(player_name)
+    expect(draft_room).to have_selected_player(player_name)
 
     team_with_second_pick = league_on_page.league_team_with_pick(@league, 2).name
     expect(draft_room).to have_team_on_the_clock(team_with_second_pick)
@@ -60,19 +61,21 @@ feature 'League draft room', js: true do
     league_on_page.enter_draft
 
     expect(draft_room).to have_text 'Fantasy Sports Dojo Draft'
-    expect(draft_room).to have_no_link draft_room.first_player_name
+    expect(draft_room).to have_no_link draft_room.get_player_name(Player.first)
   end
 
   scenario 'completes the draft when no picks remain' do
-    league = create(:football_league, :with_draft_in_progress, name: 'Completed draft')
+    league = create(:football_league, :with_draft_in_progress, name: 'Nearly completed draft')
     league_member = create(:user)
-    team = create(:team, league: league, user: league_member)
-    create(:pick, team: team)
+    create(:team, league: league, user: league_member)
+    fill_league league
+    generate_draft_picks league
+    select_players_with_picks(league, league.picks.first(11))
 
     sign_in league_member
     navigate_to_league(league.name)
     league_on_page.enter_draft
-    draft_room.select_player(draft_room.first_player_name)
+    draft_room.select_player(draft_room.get_player_name(Player.last))
 
     expect(draft_room).to have_link_to_draft_results
   end
@@ -132,7 +135,7 @@ feature 'League draft room', js: true do
 
       draft_room.let_pick_timer_run(4)
       time_remaining_before_making_pick = draft_room.time_remaining
-      draft_room.select_player(draft_room.first_available_player_name)
+      draft_room.select_player(draft_room.get_player_name(Player.first))
       expect(draft_room.time_remaining).to be > time_remaining_before_making_pick
     end
 

--- a/spec/features/league_member_spec.rb
+++ b/spec/features/league_member_spec.rb
@@ -23,6 +23,8 @@ feature 'League members' do
   scenario 'can join a draft in progress' do
     league = create(:football_league, :with_draft_in_progress)
     create(:team, league: league, user: @member)
+    fill_league league
+    generate_draft_picks league
 
     navigate_to_league
     expect(page).to have_link 'Join Draft'

--- a/spec/models/player_spec.rb
+++ b/spec/models/player_spec.rb
@@ -24,22 +24,33 @@ describe Player do
       end
 
       it 'inserts new players' do
-        expect(Player.all).to be_empty
+        expect(Player.where(deleted_at: nil)).to be_empty
 
         Player.update_player_pool
-
-        expect(Player.all.length).to eq 1
       end
 
       it 'updates existing players' do
         create(:player, sport: @football)
 
-        expect(Player.all.length).to eq 1
+        expect(Player.where(deleted_at: nil).count).to eq 1
 
         Player.update_player_pool
       end
 
+      it 'marks old players as deleted' do
+        old_player =
+          create(:player, sport: @football, first_name: 'Josh', last_name: 'Prince', orig_id: '-1')
+
+        expect(Player.where(deleted_at: nil).count).to eq 1
+
+        Player.update_player_pool
+
+        expect(old_player.reload.deleted_at).to be_truthy
+      end
+
       after do
+        expect(Player.where(deleted_at: nil).count).to eq 1
+
         player = Player.last
         expect(player.first_name).to eq 'Tom'
         expect(player.last_name).to eq 'Brady'
@@ -63,9 +74,19 @@ describe Player do
         league = create(:league, sport: @football)
         team = create(:team, league: league)
 
-        expect(Player.undrafted(League.last).length).to eq 2
+        expect(Player.undrafted(League.last).count).to eq 2
         create(:pick, player: drafted_player, team: team)
-        expect(Player.undrafted(League.last).length).to eq 1
+        expect(Player.undrafted(League.last).count).to eq 1
+      end
+
+      it 'does not return deleted players' do
+        create(:player, last_name: 'undrafted', sport: @football)
+        create(:player, last_name: 'deleted', sport: @football, deleted_at: Time.zone.now)
+
+        league = create(:league, sport: @football)
+        undrafted_players = Player.undrafted(league)
+        expect(undrafted_players.count).to eq 1
+        expect(undrafted_players.first.last_name).to eq 'undrafted'
       end
     end
   end

--- a/spec/models/player_spec.rb
+++ b/spec/models/player_spec.rb
@@ -48,6 +48,14 @@ describe Player do
         expect(old_player.reload.deleted_at).to be_truthy
       end
 
+      it 'restores deleted players' do
+        create(:player, sport: @football, deleted_at: Time.zone.now)
+
+        expect(Player.where(deleted_at: nil).count).to eq 0
+
+        Player.update_player_pool
+      end
+
       after do
         expect(Player.where(deleted_at: nil).count).to eq 1
 
@@ -64,6 +72,7 @@ describe Player do
         expect(player.pro_status).to eq 'A'
         expect(player.sport_id).to eq @football.id.to_s
         expect(player.orig_id).to eq '1'
+        expect(player.deleted_at).to be_nil
       end
     end
 

--- a/spec/support/factories.rb
+++ b/spec/support/factories.rb
@@ -11,7 +11,7 @@ FactoryGirl.define do
     draft_status { DraftStatus.find_or_create_by(description: 'Not Started') }
     name 'Fantasy Sports Dojo'
     password 'password'
-    rounds 15
+    rounds 1
     size 12
     user
 

--- a/spec/support/page_objects/draft_room.rb
+++ b/spec/support/page_objects/draft_room.rb
@@ -1,13 +1,5 @@
 module Pages
   class DraftRoom < Base
-    def first_available_player_name
-      first('.player').find('.select').text
-    end
-
-    def first_player_name
-      get_player_name(Player.first)
-    end
-
     def has_keeper_in_upcoming_picks?(player_name)
       within find('.upcoming-picks') do
         has_player_in_ticker player_name


### PR DESCRIPTION
Players that are no longer active (i.e. retired) should be removed from the player pool so that they are not draftable.

This is achieved using soft-deletes, to maintain referential integrity for historical draft results. While my preference is to use a library, like [paranoia](https://github.com/rubysherpas/paranoia), to achieve this, most have not implemented support for Rails 5 yet.

This is currently not merge-able due to an issue where the CBS sports API removes players from its player pool when they go on the bereavement list.
