### PR TITLE
Improve draft room performance

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,7 +9,6 @@ AllCops:
     - Gemfile
     - Rakefile
     - config.ru
-  TargetRubyVersion: 2.2.3
 
 ClassLength:
   Enabled: false

--- a/app/assets/javascripts/components/draft_room.js.jsx.coffee
+++ b/app/assets/javascripts/components/draft_room.js.jsx.coffee
@@ -1,15 +1,11 @@
-@pickDuration = 120
 @DraftRoom = React.createClass
-  clearSearch: ->
-    @setState({ searchText: '' })
-    @refs.playerSearch.value = '' if @refs.playerSearch?
   closeConfirmationModal: (e) ->
     e.preventDefault()
-    @setState({ playerToBeDrafted: { id: undefined, name: undefined } })
+    @setState(playerToBeDrafted: { id: undefined, name: undefined })
     $('#confirm-modal').closeModal()
   componentDidMount: -> @setupSubscription()
   componentWillMount: ->
-    @delayedSearchCallback = _.debounce(((e) -> @setState({ searchText: e.target.value })), 300)
+    @delayedSearchCallback = _.debounce(((e) -> @setState(searchText: e.target.value)), 300)
   getInitialState: ->
     selectedPosition = getFirstOption(@props.positions)
 
@@ -27,33 +23,38 @@
     if selectedPosition is 'ALL' then players else _(players).filter(position: selectedPosition)
   openSelectPlayerModal: (selectedPlayerId, e) ->
     e.preventDefault()
-    playerName = getPlayerName(_(@state.players).findWhere({id: selectedPlayerId}))
-    @setState({ playerToBeDrafted: { id: selectedPlayerId, name: playerName }})
+    playerName = _(@state.players).findWhere(id: selectedPlayerId).name
+    @setState(playerToBeDrafted: { id: selectedPlayerId, name: playerName })
     $('#confirm-modal').openModal()
   refreshData: (updatedData) ->
     return unless updatedData?
+    lastSelectedPlayer = updatedData.lastSelectedPlayer
+
     if updatedData.isUndo
-      @state.players.push updatedData.lastSelectedPlayer
-      updatedPlayers = _(@state.players).sortBy (player) -> player.lastName
+      @state.players.push lastSelectedPlayer
+      updatedPlayers = _(@state.players).sortBy (player) -> player.name
     else if updatedData.lastSelectedPlayer?
-      selectedPlayer = updatedData.lastSelectedPlayer
-      updatedPlayers = _(@state.players).reject (player) -> player.id is selectedPlayer.id
+      updatedPlayers = _(@state.players).reject (player) -> player.id is lastSelectedPlayer.id
       pickInfo = "Pick #{@state.currentPick.roundPick} (#{@state.currentPick.overallPick} overall)"
-      selectedPlayerInfo =
+      lastSelectedPlayer =
         draftPosition: "Round #{@state.currentPick.round} | #{pickInfo}"
-        info: "#{selectedPlayer.team} #{selectedPlayer.position}"
-        name: "#{selectedPlayer.firstName} #{selectedPlayer.lastName}"
-        photo: selectedPlayer.photoUrl
+        info: "#{lastSelectedPlayer.team} #{lastSelectedPlayer.position}"
+        name: "#{lastSelectedPlayer.firstName} #{lastSelectedPlayer.lastName}"
+        photo: lastSelectedPlayer.photoUrl
         team: _(@props.teams).findWhere(id: @state.currentPick.teamId).name
-      @setState({ lastSelectedPlayer: selectedPlayerInfo })
       playerModalTimeout = setTimeout((-> $('#player-modal').closeModal()), 12000)
       $('#player-modal').openModal(complete: -> clearTimeout(playerModalTimeout))
-    @setState({ draftStatus: updatedData.draftStatus })
-    @setState({ picks: @updatePicks(updatedData.lastSelectedPlayer, updatedData.isUndo) })
-    @setState({ players: @filterPlayersByPosition(@state.selectedPosition, updatedPlayers) })
-    @setState({ playerToBeDrafted: { id: undefined, name: undefined } })
-    @setState({ currentPick: updatedData.currentPick })
-    @setState({ userIsOnTheClock: @props.currentTeam.id is updatedData.currentPick?.teamId })
+    @setState(
+      currentPick: updatedData.currentPick
+      draftStatus: updatedData.draftStatus
+      lastSelectedPlayer: lastSelectedPlayer
+      picks: @updatePicks(updatedData.lastSelectedPlayer, updatedData.isUndo)
+      players: @filterPlayersByPosition(@state.selectedPosition, updatedPlayers)
+      playerToBeDrafted: { id: undefined, name: undefined }
+      searchText: ''
+      userIsOnTheClock: @props.currentTeam.id is updatedData.currentPick?.teamId
+    )
+    @refs.playerSearch.value = '' if @refs.playerSearch?
   selectPlayer: (e) ->
     e.preventDefault()
 
@@ -67,7 +68,6 @@
       method: 'POST'
       url: url
       success: ((updatedData) =>
-        @clearSearch()
         $('#confirm-modal').closeModal()
         @refreshData(updatedData)
       ).bind(@)
@@ -100,7 +100,7 @@
           if isUndo
             undefined
           else
-            "#{lastSelectedPlayer.lastName}, #{lastSelectedPlayer.firstName}"
+            lastSelectedPlayer.name
     picks
   updateSearchText: (e) ->
     e.persist()
@@ -180,111 +180,3 @@
           userCanSelectPlayers={this.state.userIsLeagueManager || this.state.userIsOnTheClock}
         />
        </div>`
-
-@DraftTicker = React.createClass
-  componentWillReceiveProps: (newProps) -> @setState({ currentPickId: newProps.currentPick?.id })
-  getInitialState: ->
-    currentPickId: @props.currentPick?.id
-    timerPaused: false
-  getTeamNameById: (id) -> _(@props.teams).findWhere(id: id)?.name
-  togglePause: -> @setState({ timerPaused: not @state.timerPaused })
-  render: ->
-    indexOfCurrentPick = (@props.picks.map (pick) -> pick.id).indexOf(@state.currentPickId)
-    startingPick = _([0, indexOfCurrentPick - 8]).max()
-    recentPicksArray = @props.picks.slice(startingPick, indexOfCurrentPick)
-    upcomingPicksArray = @props.picks.slice(indexOfCurrentPick + 1, indexOfCurrentPick + 9)
-    recentPicks = recentPicksArray.map ((pick, i) ->
-      `<Pick key={i} pick={pick} teamName={this.getTeamNameById(pick.teamId)} />`
-    ).bind(@)
-    upcomingPicks = upcomingPicksArray.map ((pick, i) ->
-      `<Pick key={i} pick={pick} teamName={this.getTeamNameById(pick.teamId)} />`
-    ).bind(@)
-
-    pausePlayIcon =
-      if @state.timerPaused
-        `<i className="material-icons">play_arrow</i>`
-      else
-        `<i className="material-icons">pause</i>`
-
-    adminButtons =
-      if @props.showAdminButtons
-        `<div>
-          <button
-            className="btn btn-icon waves-effect waves-light"
-            id="toggle-pause-pick-timer"
-            onClick={this.togglePause}
-            type="button"
-          >
-            {pausePlayIcon}
-          </button>
-          <button
-            className="btn btn-icon waves-effect waves-light"
-            id="undo-last-pick"
-            onClick={this.props.undoLastPick}
-            type="button"
-          >
-            <i className="material-icons">undo</i>
-          </button>
-        </div>`
-      else
-        null
-
-    `<div id="draft-ticker">
-      <div className="row recent-picks">{recentPicks}</div>
-      <div className="row clear-floats"></div>
-      <div id="current-pick" className="row valign-wrapper">
-        <div className="col s4 offset-s4 center-align valign">
-          <div>Round {this.props.currentPick.round} | Pick {this.props.currentPick.roundPick}</div>
-          <div>On the clock: {this.getTeamNameById(this.props.currentPick.teamId)}</div>
-          <PickTimer
-            currentPickId={this.state.currentPickId}
-            isPaused={this.state.timerPaused}
-            userIsOnTheClock={this.props.userIsOnTheClock}
-          />
-        </div>
-        <div className="col s2 valign">{adminButtons}</div>
-        <div className="col s2 valign"></div>
-      </div>
-      <div className="clear-floats"></div>
-      <div className="row upcoming-picks">{upcomingPicks}</div>
-    </div>`
-
-@PickTimer = React.createClass
-  componentDidMount: -> @runTimer()
-  componentWillReceiveProps: (newProps) ->
-    if newProps.isPaused isnt @state.isPaused
-      @pause()
-    else
-      if newProps.currentPickId isnt @state.currentPickId
-        @setState({ currentPickId: newProps.currentPickId })
-        @setState({ secondsRemaining: pickDuration })
-        if @state.timeExpired
-          @setState({ timeExpired: false })
-          clearInterval(@interval)
-          @runTimer()
-  componentWillUnmount: -> clearInterval(@interval)
-  getInitialState: ->
-    currentPickId: undefined
-    isPaused: false
-    secondsRemaining: pickDuration
-    timeExpired: false
-  pause: ->
-    if not @state.isPaused
-      clearInterval(@interval)
-    else
-      @runTimer()
-
-    @setState({ isPaused: not @state.isPaused })
-  tick: ->
-    @setState({ secondsRemaining: @state.secondsRemaining - 1 })
-    if @state.secondsRemaining in [1..30]
-      classes = if @state.secondsRemaining <= 10 then 'red darken-2' else 'orange darken-1'
-      Materialize.toast(@state.secondsRemaining, 1000, classes)
-    else if @state.secondsRemaining <= 0
-      if @props.userIsOnTheClock
-        Materialize.toast("Time's up, bitch! Pick somebody.", 10000, 'red darken-2')
-      @setState({ timeExpired: true })
-      clearInterval(@interval)
-  runTimer: -> @interval = setInterval(@tick, 1000)
-  render: ->
-    `<div>Time remaining: <span id="time-remaining">{this.state.secondsRemaining}</span></div>`

--- a/app/assets/javascripts/components/draft_ticker.js.jsx.coffee
+++ b/app/assets/javascripts/components/draft_ticker.js.jsx.coffee
@@ -1,0 +1,67 @@
+@DraftTicker = React.createClass
+  componentWillReceiveProps: (newProps) -> @setState({ currentPickId: newProps.currentPick?.id })
+  getInitialState: ->
+    currentPickId: @props.currentPick?.id
+    timerPaused: false
+  getTeamNameById: (id) -> _(@props.teams).findWhere(id: id)?.name
+  togglePause: -> @setState({ timerPaused: not @state.timerPaused })
+  render: ->
+    indexOfCurrentPick = (@props.picks.map (pick) -> pick.id).indexOf(@state.currentPickId)
+    startingPick = _([0, indexOfCurrentPick - 8]).max()
+    recentPicksArray = @props.picks.slice(startingPick, indexOfCurrentPick)
+    upcomingPicksArray = @props.picks.slice(indexOfCurrentPick + 1, indexOfCurrentPick + 9)
+    recentPicks = recentPicksArray.map ((pick, i) ->
+      `<Pick key={i} pick={pick} teamName={this.getTeamNameById(pick.teamId)} />`
+    ).bind(@)
+    upcomingPicks = upcomingPicksArray.map ((pick, i) ->
+      `<Pick key={i} pick={pick} teamName={this.getTeamNameById(pick.teamId)} />`
+    ).bind(@)
+
+    pausePlayIcon =
+      if @state.timerPaused
+        `<i className="material-icons">play_arrow</i>`
+      else
+        `<i className="material-icons">pause</i>`
+
+    adminButtons =
+      if @props.showAdminButtons
+        `<div>
+          <button
+            className="btn btn-icon waves-effect waves-light"
+            id="toggle-pause-pick-timer"
+            onClick={this.togglePause}
+            type="button"
+          >
+            {pausePlayIcon}
+          </button>
+          <button
+            className="btn btn-icon waves-effect waves-light"
+            id="undo-last-pick"
+            onClick={this.props.undoLastPick}
+            type="button"
+          >
+            <i className="material-icons">undo</i>
+          </button>
+        </div>`
+      else
+        null
+
+    `<div id="draft-ticker">
+      <div className="row recent-picks">{recentPicks}</div>
+      <div className="row clear-floats"></div>
+      <div id="current-pick" className="row valign-wrapper">
+        <div className="col s4 offset-s4 center-align valign">
+          <div>Round {this.props.currentPick.round} | Pick {this.props.currentPick.roundPick}</div>
+          <div>On the clock: {this.getTeamNameById(this.props.currentPick.teamId)}</div>
+          <PickTimer
+            currentPickId={this.state.currentPickId}
+            isPaused={this.state.timerPaused}
+            userIsOnTheClock={this.props.userIsOnTheClock}
+          />
+        </div>
+        <div className="col s2 valign">{adminButtons}</div>
+        <div className="col s2 valign"></div>
+      </div>
+      <div className="clear-floats"></div>
+      <div className="row upcoming-picks">{upcomingPicks}</div>
+    </div>`

--- a/app/assets/javascripts/components/pick_timer.js.jsx.coffee
+++ b/app/assets/javascripts/components/pick_timer.js.jsx.coffee
@@ -1,0 +1,40 @@
+@pickDuration = 120
+@PickTimer = React.createClass
+  componentDidMount: -> @runTimer()
+  componentWillReceiveProps: (newProps) ->
+    if newProps.isPaused isnt @state.isPaused
+      @pause()
+    else
+      if newProps.currentPickId isnt @state.currentPickId
+        @setState({ currentPickId: newProps.currentPickId })
+        @setState({ secondsRemaining: pickDuration })
+        if @state.timeExpired
+          @setState({ timeExpired: false })
+          clearInterval(@interval)
+          @runTimer()
+  componentWillUnmount: -> clearInterval(@interval)
+  getInitialState: ->
+    currentPickId: undefined
+    isPaused: false
+    secondsRemaining: pickDuration
+    timeExpired: false
+  pause: ->
+    if not @state.isPaused
+      clearInterval(@interval)
+    else
+      @runTimer()
+
+    @setState({ isPaused: not @state.isPaused })
+  tick: ->
+    @setState({ secondsRemaining: @state.secondsRemaining - 1 })
+    if @state.secondsRemaining in [1..30]
+      classes = if @state.secondsRemaining <= 10 then 'red darken-2' else 'orange darken-1'
+      Materialize.toast(@state.secondsRemaining, 1000, classes)
+    else if @state.secondsRemaining <= 0
+      if @props.userIsOnTheClock
+        Materialize.toast("Time's up, bitch! Pick somebody.", 10000, 'red darken-2')
+      @setState({ timeExpired: true })
+      clearInterval(@interval)
+  runTimer: -> @interval = setInterval(@tick, 1000)
+  render: ->
+    `<div>Time remaining: <span id="time-remaining">{this.state.secondsRemaining}</span></div>`

--- a/app/assets/javascripts/components/players.js.jsx.coffee
+++ b/app/assets/javascripts/components/players.js.jsx.coffee
@@ -1,19 +1,15 @@
 @Player = React.createClass
-  componentWillReceiveProps: (newProps) ->
-    @setState({ userCanSelectPlayers: newProps.userCanSelectPlayers })
-  getInitialState: -> userCanSelectPlayers: @props.userCanSelectPlayers
   render: ->
     player = @props.player
-    playerName = getPlayerName(player)
     playerNameCellContent =
-      if @state.userCanSelectPlayers
+      if @props.userCanSelectPlayers
         `<a href="" className="select" onClick={this.props.onSelect.bind(null, player.id)}>
-          {playerName}
+          {player.name}
         </a>`
       else
-        `<span>{playerName}</span>`
+        `<span>{player.name}</span>`
     icons =
-      if player.injury
+      if player.injury?
         `<i
            className="injury material-icons red-text text-darken-4 tooltipped"
            data-tooltip={player.injury}
@@ -33,11 +29,15 @@
 @PlayersIndex = React.createClass
   componentDidMount: -> $('.tooltipped').tooltip({delay: 100})
   componentDidUpdate: -> $('.tooltipped').tooltip({delay: 100})
+  shouldComponentUpdate: (nextProps, nextState) ->
+    @props.players isnt nextProps.players or @props.searchText isnt nextProps.searchText
   render: ->
     searchText = @props.searchText.trim().toLowerCase()
     filteredPlayers = _(@props.players).filter (player) ->
-      getPlayerName(player).trim().toLowerCase().match searchText
-    players = filteredPlayers.map ((player, i) ->
+      player.name.trim().toLowerCase().match searchText
+    displayedPlayers = filteredPlayers.slice(0, 100)
+
+    players = displayedPlayers.map ((player, i) ->
       `<Player
         key={i}
         player={player}
@@ -46,16 +46,27 @@
       />`
     ).bind(@)
 
-    `<table className="hoverable">
-      <thead>
-        <tr>
-          <th>Name</th>
-          <th>Position</th>
-          <th>Team</th>
-          <th>News</th>
-        </tr>
-      </thead>
-      <tbody>
-        {players}
-      </tbody>
-    </table>`
+    truncationMessage =
+      if filteredPlayers.length > displayedPlayers.length
+        `<div id="truncation-message">
+          Showing top 100 results. Please filter or search to see more.
+        </div>`
+      else
+        null
+
+    `<div>
+      <table className="hoverable">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Position</th>
+            <th>Team</th>
+            <th>News</th>
+          </tr>
+        </thead>
+        <tbody>
+          {players}
+        </tbody>
+      </table>
+      {truncationMessage}
+    </div>`

--- a/app/assets/javascripts/components/shared.js.jsx.coffee
+++ b/app/assets/javascripts/components/shared.js.jsx.coffee
@@ -1,10 +1,4 @@
 @getFirstOption = (options) -> if _(options).any() then options[0].value else null
-@getPlayerName = (player) ->
-  return unless player?
-  if !!player.firstName
-    "#{player.lastName}, #{player.firstName}"
-  else
-    player.lastName
 @getSecondOption = (options) -> if _(options).any() then options[1].value else null
 @getSelection = (options) ->
   selection = []

--- a/app/assets/stylesheets/_draft-room.scss
+++ b/app/assets/stylesheets/_draft-room.scss
@@ -57,3 +57,10 @@
     text-align: right;
   }
 }
+
+#truncation-message {
+  font-style: italic;
+  font-weight: 500;
+  margin-top: 1em;
+  text-align: center;
+}

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -37,4 +37,6 @@ ul.hmenu li { display: inline; }
 
 .collection a.collection-item { color: $grey-darken-3; }
 
+.container { margin-bottom: 2em; }
+
 .warning { font-style: italic; }

--- a/app/controllers/draft_picks_controller.rb
+++ b/app/controllers/draft_picks_controller.rb
@@ -27,8 +27,7 @@ class DraftPicksController < ApplicationController
         is_undo: true,
         last_selected_player: {
           id: last_pick_player.id,
-          first_name: last_pick_player.first_name,
-          last_name: last_pick_player.last_name,
+          name: last_pick_player.name,
           photo_url: last_pick_player.photo_url,
           position: last_pick_player.position,
           team: last_pick_player.team,

--- a/app/models/league.rb
+++ b/app/models/league.rb
@@ -42,8 +42,9 @@ class League < ActiveRecord::Base
   private
 
   def player_info(player_id)
-    Player.select(:id, :first_name, :last_name, :position, :team, :injury, :headline, :photo_url)
-          .find(player_id)
-          .attributes
+    player =
+      Player.select(:id, :first_name, :last_name, :position, :team, :injury, :headline, :photo_url)
+            .find(player_id)
+    player.attributes.merge('name' => player.name)
   end
 end

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -9,10 +9,14 @@ class Player < ActiveRecord::Base
   has_many :picks
   has_many :teams, through: :picks
 
+  def name
+    first_name.blank? ? last_name : "#{last_name}, #{first_name}"
+  end
+
   def self.undrafted(league)
     players = league.sport.players.to_a
-    drafted_player_ids = league.picks.map(&:player).compact.map(&:id)
-    players.reject { |player| drafted_player_ids.include? player.id }
+    drafted_player_ids = league.picks.where.not(player_id: nil).pluck(:player_id)
+    players.reject! { |player| drafted_player_ids.include? player.id } || players
   end
 
   def self.update_player_pool

--- a/app/views/drafts/show.json.jbuilder
+++ b/app/views/drafts/show.json.jbuilder
@@ -14,7 +14,7 @@ json.picks(@picks) do |pick|
 end
 
 json.players(@players) do |player|
-  json.extract! player, :first_name, :id, :last_name, :position, :team, :injury, :headline, :photo_url
+  json.extract! player, :id, :name, :position, :team, :injury, :headline, :photo_url
 end
 
 json.positions(@positions) do |position|

--- a/app/views/keepers/_edit.json.jbuilder
+++ b/app/views/keepers/_edit.json.jbuilder
@@ -3,7 +3,7 @@ json.keepers(@keepers) do |keeper|
 
   json.pick "Rd: #{pick.round}, Pick: #{pick.round_pick} (#{pick.overall_pick} overall)"
   json.pickId pick.id
-  json.playerName keeper.first_name.empty? ? keeper.last_name : "#{keeper.last_name}, #{keeper.first_name}"
+  json.playerName keeper.name
   json.teamId pick.team_id
 end
 
@@ -17,7 +17,7 @@ end
 
 json.players(@available_players) do |player|
   json.value player.id
-  json.name player.first_name.empty? ? player.last_name : "#{player.last_name}, #{player.first_name}"
+  json.name player.name
   json.position player.position
 end
 

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -13,7 +13,7 @@
     <div class="position-section <%= position.downcase %>">
       <% @players.select{|player| player['position'] == position}.each do |player| %>
         <ul>
-          <li><%= player.first_name.blank? ? player.last_name : "#{player.last_name}, #{player.first_name}" %></li>
+          <li><%= player.name %></li>
         </ul>
       <% end %>
     </div>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -55,5 +55,6 @@ Rails.application.configure do
   # config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
   # Which React.js build (development, production, with or without add-ons) to serve
+  config.react.addons = true
   config.react.variant = :development
 end

--- a/spec/controllers/draft_picks_controller_spec.rb
+++ b/spec/controllers/draft_picks_controller_spec.rb
@@ -94,8 +94,7 @@ describe DraftPicksController do
         is_undo: true,
         last_selected_player: {
           id: player.id,
-          first_name: player.first_name,
-          last_name: player.last_name,
+          name: "#{player.last_name}, #{player.first_name}",
           photo_url: player.photo_url,
           position: player.position,
           team: player.team,

--- a/spec/features/draft_spec.rb
+++ b/spec/features/draft_spec.rb
@@ -77,7 +77,7 @@ feature 'League draft room', js: true do
     sign_in league_member
     navigate_to_league(league.name)
     league_on_page.enter_draft
-    draft_room.select_player(draft_room.get_player_name(Player.last))
+    draft_room.select_player(draft_room.get_player_name(Player.undrafted(league).first))
 
     expect(draft_room).to have_link_to_draft_results
   end

--- a/spec/models/league_spec.rb
+++ b/spec/models/league_spec.rb
@@ -97,6 +97,7 @@ describe League do
         'id' => selected_player.id,
         'first_name' => selected_player.first_name,
         'last_name' => selected_player.last_name,
+        'name' => "#{selected_player.last_name}, #{selected_player.first_name}",
         'position' => selected_player.position,
         'photo_url' => selected_player.photo_url,
         'team' => selected_player.team,

--- a/spec/models/player_spec.rb
+++ b/spec/models/player_spec.rb
@@ -14,7 +14,20 @@ describe Player do
   context 'All sports' do
     before do
       allow(STDOUT).to receive(:write)
-      @football = Sport.find_by(name: 'Football')
+    end
+
+    let(:football) { Sport.find_by(name: 'Football') }
+
+    describe '#name' do
+      it "formats as 'last_name, first_name'" do
+        player = create(:player, first_name: 'Josh', last_name: 'Prince', sport: football)
+        expect(player.name).to eq 'Prince, Josh'
+      end
+
+      it "returns the last_name if the player's first_name is blank" do
+        player = create(:player, first_name: nil, last_name: 'Patriots', sport: football)
+        expect(player.name).to eq 'Patriots'
+      end
     end
 
     describe '.update_player_pool' do
@@ -32,7 +45,7 @@ describe Player do
       end
 
       it 'updates existing players' do
-        create(:player, sport: @football)
+        create(:player, sport: football)
 
         expect(Player.all.length).to eq 1
 
@@ -51,16 +64,16 @@ describe Player do
           'http://sports.cbsimg.net/images/blogs/Tom-brady.turkey.400.jpg'
         )
         expect(player.pro_status).to eq 'A'
-        expect(player.sport_id).to eq @football.id.to_s
+        expect(player.sport_id).to eq football.id.to_s
         expect(player.orig_id).to eq '1'
       end
     end
 
     describe '.undrafted' do
       it 'returns only undrafted players for a league' do
-        create(:player, last_name: 'undrafted', sport: @football)
-        drafted_player = create(:player, last_name: 'drafted', sport: @football)
-        league = create(:league, sport: @football)
+        create(:player, last_name: 'undrafted', sport: football)
+        drafted_player = create(:player, last_name: 'drafted', sport: football)
+        league = create(:league, sport: football)
         team = create(:team, league: league)
 
         expect(Player.undrafted(League.last).length).to eq 2

--- a/spec/support/page_objects/keeper_page.rb
+++ b/spec/support/page_objects/keeper_page.rb
@@ -30,6 +30,7 @@ module Pages
 
     def select_team(team_name)
       select(team_name, from: 'team-select')
+      sleep 0.5
     end
   end
 end


### PR DESCRIPTION
**Why:**
The draft room React code was not well-written. The various performance issues didn't really manifest themselves during the football draft because football has so few players relative to baseball. Prior to these changes, drafting a baseball player took ~14 seconds. This is largely due to the numerous state changes that were occurring, which triggered 7 unnecessary re-renderings of the draft room component. Another major performance hit was the fact that there were almost 7k players that needed to re-render each time. Even after some optimization of that code, that particular component of the lifecycle still took ~2.5 seconds.

After these changes, drafting a baseball player takes ~94ms.

**How:**
- Group state updates into a single update
- Prevent the PlayerIndex from re-rendering on state change unless it was the player pool or search text that changed.
- Only show 100 players at a time (require the user to filter or search if the player isn't displayed). This greatly improves performance by reducing the number of player component renderings.